### PR TITLE
Serve internal api for top 3 neighborhoods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'faraday'
 gem 'google-api-client', '0.9'
 gem 'haversine'
 gem 'geocoder'
+gem 'responders', '~> 2.0'
 
 group :production do
 gem 'rails_12factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,8 @@ GEM
       json (~> 1.4)
     representable (2.3.0)
       uber (~> 0.0.7)
+    responders (2.2.0)
+      railties (>= 4.2.0, < 5.1)
     retriable (2.1.0)
     rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
@@ -244,11 +246,15 @@ DEPENDENCIES
   pry-rails
   rails (= 4.2.6)
   rails_12factor
+  responders (~> 2.0)
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,0 +1,5 @@
+module Api
+  class ApiController < ApplicationController
+    protect_from_forgery with: :null_session
+  end
+end

--- a/app/controllers/api/v1/neighborhoods_controller.rb
+++ b/app/controllers/api/v1/neighborhoods_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  module V1
+    class NeighborhoodsController < ApiController
+      respond_to :json
+
+      def index
+        params = {
+          "Address 1"=>"1510 Blake st. Denver CO",
+          "Address 2"=>"Elkhart Elementary Aurora CO",
+          "Address 3"=>"Denver Art Museum"
+        }
+        @top_three = NeighborhoodAnalyst.top_three_neighborhoods(params)
+          results = @top_three.map do |neighborhood|
+            Hash[["Distance", "Neighborhood"].zip(neighborhood)]
+          end
+        render json: results
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/neighborhoods_controller.rb
+++ b/app/controllers/api/v1/neighborhoods_controller.rb
@@ -10,10 +10,7 @@ module Api
           "Address 3"=>"Denver Art Museum"
         }
         @top_three = NeighborhoodAnalyst.top_three_neighborhoods(params)
-          results = @top_three.map do |neighborhood|
-            Hash[["Distance", "Neighborhood"].zip(neighborhood)]
-          end
-        render json: results
+        render json: @top_three
       end
     end
   end

--- a/app/controllers/api/v1/neighborhoods_controller.rb
+++ b/app/controllers/api/v1/neighborhoods_controller.rb
@@ -4,11 +4,6 @@ module Api
       respond_to :json
 
       def index
-        params = {
-          "Address 1"=>"1510 Blake st. Denver CO",
-          "Address 2"=>"Elkhart Elementary Aurora CO",
-          "Address 3"=>"Denver Art Museum"
-        }
         @top_three = NeighborhoodAnalyst.top_three_neighborhoods(params)
         render json: @top_three
       end

--- a/app/models/neighborhood_analyst.rb
+++ b/app/models/neighborhood_analyst.rb
@@ -26,6 +26,8 @@ class NeighborhoodAnalyst
       end
     end.map { |result| (result.reduce :+) / 180 }.zip(results.map do |r|
       r[0]
-    end).sort.take(3)
+    end).sort.take(3).map do |neighborhood|
+      Hash[["Distance", "Neighborhood"].zip(neighborhood)]
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 Rails.application.routes.draw do
   root 'homes#index'
-  # resources :homes, only: [:index]
   get '/homes', to: 'homes#index'
   post '/homes', to: 'homes#create'
+
+  namespace :api, defaults: {format: :json} do
+    namespace :v1 do
+      resources :neighborhoods, only: [:index]
+    end
+  end
 end


### PR DESCRIPTION
We got some awesome help from Code for Denver peeps who are making a pretty, mobile-responsive, client-side app in React that will send AJAX requests to our Rails backend.

This PR creates an API endpoint `/api/v1/neighborhoods` that returns the top 3 neighborhoods, expecting the `get` request to come with 3 params of the 3 addresses.

I'm going to merge this so we can keep working on the client-side app, but please take a look when you can @NickyBobby @thompickett 
